### PR TITLE
feat(api): RuffによるLint/Format設定を導入（Issue #90）

### DIFF
--- a/apps/api/Makefile
+++ b/apps/api/Makefile
@@ -1,0 +1,20 @@
+.PHONY: lint format check fix help
+
+help:
+	@echo "Usage:"
+	@echo "  make lint    - Ruffでlintチェック（修正なし）"
+	@echo "  make format  - Ruffでフォーマットチェック（修正なし）"
+	@echo "  make check   - lint + format を両方チェック（CI用）"
+	@echo "  make fix     - lint自動修正 + フォーマット適用（開発用）"
+
+lint:
+	uv run ruff check .
+
+format:
+	uv run ruff format --check .
+
+check: lint format
+
+fix:
+	uv run ruff check --fix .
+	uv run ruff format .

--- a/apps/api/config.py
+++ b/apps/api/config.py
@@ -3,7 +3,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
 
     tidb_host: str = ""
     tidb_port: int = 4000
@@ -24,5 +26,6 @@ class Settings(BaseSettings):
 
     app_env: str = "development"
     daily_token_limit: int = 10000
+
 
 settings = Settings()

--- a/apps/api/db/session.py
+++ b/apps/api/db/session.py
@@ -37,7 +37,7 @@ AsyncSessionLocal = async_sessionmaker(
 )
 
 
-async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
+async def get_db_session() -> AsyncGenerator[AsyncSession]:
     """FastAPI Depends 用。リクエストスコープでセッションを提供し自動クローズ。"""
     async with AsyncSessionLocal() as session:
         yield session

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from middleware.request_id import RequestIDMiddleware
-from routers import health, consent, feedback
+from routers import consent, feedback, health
 
 app = FastAPI(title="Jyogi Navi API", version="0.1.0")
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -22,4 +22,41 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "httpx>=0.26.0",
+    "ruff>=0.4.0",
 ]
+
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes（未使用import、未定義変数等）
+    "I",    # isort（import順序）
+    "UP",   # pyupgrade（古い構文を新しいPython構文へ）
+    "B",    # flake8-bugbear（バグになりやすいパターン）
+    "S",    # flake8-bandit（セキュリティ）
+    "ARG",  # flake8-unused-arguments（未使用引数）
+    "PTH",  # flake8-use-pathlib
+    "RUF",  # Ruff独自ルール
+]
+ignore = [
+    "S101",   # assert使用（テストで必要）
+    "S105",   # ハードコードされたパスワード（設定読み込みで誤検知）
+    "S106",   # 同上
+    "ARG001", # 未使用引数（FastAPI Dependsパターンで必要）
+    "ARG002", # 未使用引数（middlewareシグネチャ等）
+    "B008",   # 関数呼び出しをデフォルト引数に使用（FastAPI Dependsパターン）
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/**/*.py" = ["S101", "ARG"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["config", "db", "middleware", "models", "routers", "services"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/apps/api/routers/consent.py
+++ b/apps/api/routers/consent.py
@@ -4,4 +4,3 @@ router = APIRouter(prefix="/consent", tags=["consent"])
 
 
 # TODO: セッション作成・同意更新の実装
-

--- a/apps/api/routers/feedback.py
+++ b/apps/api/routers/feedback.py
@@ -4,4 +4,3 @@ router = APIRouter(prefix="/feedback", tags=["feedback"])
 
 
 # TODO: 評価保存の実装(P1)
-

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -66,6 +66,7 @@ dependencies = [
 dev = [
     { name = "httpx" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -87,6 +88,7 @@ requires-dist = [
 dev = [
     { name = "httpx", specifier = ">=0.26.0" },
     { name = "pytest", specifier = ">=8.0.0" },
+    { name = "ruff", specifier = ">=0.4.0" },
 ]
 
 [[package]]
@@ -1015,6 +1017,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
+    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
+    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
+    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要
Issue #90「BE Ruffあたりの導入」に対応します。

`apps/api/` にRuff単体でlint + formatを完結させる設定を追加しました。Ruff v0.4.0以降はBlack互換フォーマッタ内蔵（`ruff format`）のため、BlackとRuffを両立させる複雑な設定を避けRuff単体を採用しています。

## 変更種別
- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] インフラ / CI

## 関連 Issue
closes #90

## 変更内容
- `pyproject.toml` にRuffをdev依存として追加（`ruff>=0.4.0`）
- `[tool.ruff]` 設定セクションを追加
  - `target-version = "py313"`、`line-length = 88`（Black互換）
  - lint rules: E, W, F, I, UP, B, S, ARG, PTH, RUF
  - FastAPIパターン向けignore設定（`B008`, `ARG001`, `ARG002`等）
  - isort設定（`known-first-party`にプロジェクトモジュールを列挙）
- `apps/api/Makefile` を新規作成（`lint` / `format` / `check` / `fix` ターゲット）
- 既存コードをRuffで一括フォーマット修正（import順序・行長・フォーマット等）

## テスト確認
- [x] ローカルで動作確認済み
    - `make check`（`uv run ruff check .` + `uv run ruff format --check .`）がexit code 0で完了
    - `make fix` による既存コードの一括修正を実施・確認
    - 動作環境: macOS / Python 3.13 / Ruff 0.15.6
- [x] 既存テストが通ることを確認
- [ ] 新規テストを追加した（変更内容に応じて）

## スクリーンショット（UI変更がある場合）
なし

## レビュアーへのメモ
- `db/session.py` の `AsyncGenerator[AsyncSession, None]` → `AsyncGenerator[AsyncSession]` はRuffのUP006ルール（pyupgrade）による修正で、Python 3.13では後者が推奨される書き方です。
- `main.py` のimport順序変更はisort（Iルール）による自動修正です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Ruffコードリンター・フォーマッター対応の追加設定を実装しました
  * 開発用の新しいMakefileを導入し、コード品質チェックワークフローを整備しました

* **Style**
  * コード整形基準に合わせてコードスタイルを統一しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->