### PR TITLE
fix difiポートの衝突

### DIFF
--- a/infra/dify/.env.example
+++ b/infra/dify/.env.example
@@ -89,9 +89,12 @@ DIFY_API_SECRET_KEY=your-dify-api-secret-key
 # =====================================
 # Dify UI URLs
 # =====================================
+# Dify Web のホスト公開ポート（競合時は変更）
+DIFY_WEB_PORT=3101
+
 # ローカル開発の場合
 DIFY_API_URL=http://localhost:5001
-DIFY_APP_URL=http://localhost:3001
+DIFY_APP_URL=http://localhost:3101
 
 # 本番環境（Cloudflare Tunnel など）の場合
 # DIFY_API_URL=https://dify.yourdomain.com/api
@@ -148,7 +151,7 @@ FORCE_HTTPS=false
 # 4. Google Cloud API キー取得（Gemini）
 # 5. .env.example → .env にコピー＆編集
 # 6. `docker-compose up -d` で起動
-# 7. http://localhost:3001 へアクセス
+# 7. http://localhost:3101 へアクセス
 #
 # 【トラブルシューティング】
 # - Dify API起動しない: SUPABASE DB接続確認

--- a/infra/dify/SETUP.md
+++ b/infra/dify/SETUP.md
@@ -135,7 +135,7 @@ docker-compose ps
 # 出力例:
 # NAME                COMMAND                STATUS              PORTS
 # dify-api            "python  -m dify...."  Up 2 minutes        0.0.0.0:5001->5001/tcp
-# dify-web            "npm run start"        Up 2 minutes        0.0.0.0:3001->3000/tcp
+# dify-web            "npm run start"        Up 2 minutes        0.0.0.0:3101->3000/tcp
 # dify-redis          "redis-server..."      Up 2 minutes        0.0.0.0:6379->6379/tcp
 ```
 
@@ -143,7 +143,7 @@ docker-compose ps
 
 ブラウザで開く:
 ```text
-http://localhost:3001
+http://localhost:3101
 ```
 
 初回アクセス時:
@@ -263,14 +263,14 @@ cat .env | grep GOOGLE_API_KEY
 # 4. Dify UI > Model Provider > Google で キーを再設定
 ```
 
-### 🔴 「ポート 3001 または 5001 が既に使用中」
+### 🔴 「ポート 3101 または 5001 が既に使用中」
 
-症状: `Error: listen EADDRINUSE :::3001`
+症状: `Error: listen EADDRINUSE :::3101`
 
 解決方法:
 ```bash
 # 既存プロセスを確認（Linux/Mac）
-lsof -i :3001
+lsof -i :3101
 lsof -i :5001
 
 # プロセス終了
@@ -278,7 +278,8 @@ kill -9 <PID>
 
 # または docker-compose.yml でポート番号を変更
 nano docker-compose.yml
-# dify-web: ports: ["3001:3000"]  ← 3001 に変更
+# dify-web: ports: ["${DIFY_WEB_PORT:-3101}:3000"]
+# .env の DIFY_WEB_PORT=3201 などに変更して再起動
 ```
 
 ### 🔴 「メモリ不足 (Out of Memory)」
@@ -473,7 +474,7 @@ ingress:
   - hostname: dify.yourdomain.com
     service: http://localhost:5001
   - hostname: yourdomain.com
-    service: http://localhost:3001
+    service: http://localhost:3101
   - service: http_status:404
 ```
 

--- a/infra/dify/docker-compose.yml
+++ b/infra/dify/docker-compose.yml
@@ -9,10 +9,10 @@ services:
     container_name: dify-web
     restart: unless-stopped
     ports:
-      - "3001:3000"
+      - "${DIFY_WEB_PORT:-3101}:3000"
     environment:
       NEXT_PUBLIC_API_URL: "${DIFY_API_URL:-http://localhost:5001}"
-      NEXT_PUBLIC_APP_URL: "${DIFY_APP_URL:-http://localhost:3001}"
+      NEXT_PUBLIC_APP_URL: "${DIFY_APP_URL:-http://localhost:${DIFY_WEB_PORT:-3101}}"
     depends_on:
       - dify-api
     networks:


### PR DESCRIPTION
## 概要
<!-- 何をどのように変更したか -->
dify-web のホストポートを環境変数 DIFY_WEB_PORT で管理し、デフォルトを 3101 に変更して 3000/3001 系との衝突を回避

決定した方針
Dify Web のホスト側ポートは DIFY_WEB_PORT で管理する。
既定値は 3101 とし、3000/3001 の一般的なローカル開発ポートとの衝突を避ける。
衝突時は .env の DIFY_WEB_PORT を変更して回避する。

## 変更種別
- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] インフラ / CI

## 関連 Issue
closes #92

## テスト確認
- [x] ローカルで動作確認済み
    - 変更内容に応じた動作確認の詳細（例：特定の画面での挙動確認、APIエンドポイントのレスポンス確認など）
    - [ ] 動作環境 
- [x] 既存テストが通ることを確認
- [ ] 新規テストを追加した（変更内容に応じて）

## スクリーンショット（UI変更がある場合）

## レビュアーへのメモ
<!-- レビュー時に特に見てほしい点や背景情報 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Dify Web UIのアクセスポートをポート3001からポート3101に更新しました
  * セットアップガイドのポート設定関連の手順とトラブルシューティング情報を更新しました

* **Configuration**
  * Docker Composeのポート設定が環境変数（DIFY_WEB_PORT）で構成できるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->