### PR TITLE
chore: .claude/worktrees/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Thumbs.db
 !.env.example
 
 .mcp.json
+.claude/worktrees/
 
 # Coverage reports
 coverage.xml


### PR DESCRIPTION
## 概要
`git status` に `.claude/worktrees/` が untracked files として表示されてしまうため、`.gitignore` に追加。

## 変更種別
- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [x] インフラ / CI

## 関連 Issue
closes #

## テスト確認
- [x] ローカルで動作確認済み
    - `git status` で `.claude/worktrees/` が表示されなくなることを確認
- [x] 既存テストが通ることを確認
- [ ] 新規テストを追加した（変更内容に応じて）

## スクリーンショット（UI変更がある場合）
なし

## レビュアーへのメモ
Claude Code が worktree 作業時に生成するディレクトリをトラッキング対象外にするための変更です。