### PR TITLE
feat: TanStack Query導入（QueryClient・Providers設定）

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,7 +25,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "@/lib/queryClient";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/apps/web/src/features/chat/ChatContainer.tsx
+++ b/apps/web/src/features/chat/ChatContainer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { useMutation } from "@tanstack/react-query";
 import { v4 as uuidv4 } from "uuid";
 import { Message } from "@/types/chat";
 import { ChatMessage } from "./ChatMessage";
@@ -9,9 +10,14 @@ import { ChatHeader } from "./ChatHeader";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Loader2 } from "lucide-react";
 
+async function sendChatMessage(content: string): Promise<string> {
+  // TODO: Dify API呼び出しに置き換える
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  return `ご質問ありがとうございます！「${content}」についてですね。\n\nこちらは開発中のダミーレスポンスです。実際のDify APIを統合すると、じょぎに関する詳しい情報をお答えできます。\n\n気軽に他の質問もしてくださいね！`;
+}
+
 export function ChatContainer() {
   const [messages, setMessages] = useState<Message[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // 新しいメッセージが追加されたら自動スクロール
@@ -19,9 +25,31 @@ export function ChatContainer() {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  const handleSendMessage = async (content: string) => {
+  const { mutate, isPending } = useMutation({
+    mutationFn: sendChatMessage,
+    onSuccess: (responseContent) => {
+      const assistantMessage: Message = {
+        id: uuidv4(),
+        role: "assistant",
+        content: responseContent,
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, assistantMessage]);
+    },
+    onError: () => {
+      const errorMessage: Message = {
+        id: uuidv4(),
+        role: "assistant",
+        content: "申し訳ございません。エラーが発生しました。もう一度お試しください。",
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, errorMessage]);
+    },
+  });
+
+  const handleSendMessage = (content: string) => {
     // 送信中の場合は再入を防ぐ
-    if (isLoading) {
+    if (isPending) {
       return;
     }
 
@@ -40,34 +68,7 @@ export function ChatContainer() {
     };
 
     setMessages((prev) => [...prev, userMessage]);
-    setIsLoading(true);
-
-    try {
-      // TODO: 実際のDify API呼び出しに置き換える
-      // 現在はダミーレスポンス
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-
-      const assistantMessage: Message = {
-        id: uuidv4(),
-        role: "assistant",
-        content: `ご質問ありがとうございます！「${trimmed}」についてですね。\n\nこちらは開発中のダミーレスポンスです。実際のDify APIを統合すると、じょぎに関する詳しい情報をお答えできます。\n\n気軽に他の質問もしてくださいね！`,
-        timestamp: new Date(),
-      };
-
-      setMessages((prev) => [...prev, assistantMessage]);
-    } catch (error) {
-      console.error("Error sending message:", error);
-      // エラーメッセージを表示
-      const errorMessage: Message = {
-        id: uuidv4(),
-        role: "assistant",
-        content: "申し訳ございません。エラーが発生しました。もう一度お試しください。",
-        timestamp: new Date(),
-      };
-      setMessages((prev) => [...prev, errorMessage]);
-    } finally {
-      setIsLoading(false);
-    }
+    mutate(trimmed);
   };
 
   return (
@@ -103,7 +104,7 @@ export function ChatContainer() {
                     <button
                       key={index}
                       onClick={() => handleSendMessage(example.replace(/^[^\s]+ /, ""))}
-                      disabled={isLoading}
+                      disabled={isPending}
                       className="rounded-xl border border-gray-200 bg-white p-3 text-left text-sm transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700"
                     >
                       {example}
@@ -117,7 +118,7 @@ export function ChatContainer() {
                 {messages.map((message) => (
                   <ChatMessage key={message.id} message={message} />
                 ))}
-                {isLoading && (
+                {isPending && (
                   <div className="mb-4 flex items-center gap-3" role="status">
                     <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-pink-600 text-lg">
                       🐰
@@ -138,7 +139,7 @@ export function ChatContainer() {
       {/* 入力エリア */}
       <div className="border-t border-gray-200 bg-white/80 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/80">
         <div className="mx-auto max-w-4xl px-4 py-4">
-          <ChatInput onSend={handleSendMessage} isLoading={isLoading} />
+          <ChatInput onSend={handleSendMessage} isLoading={isPending} />
         </div>
       </div>
     </div>

--- a/apps/web/src/lib/queryClient.ts
+++ b/apps/web/src/lib/queryClient.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 2,
+      staleTime: 5 * 60 * 1000, // 5分
+    },
+    mutations: {
+      retry: 1,
+    },
+  },
+});


### PR DESCRIPTION
## 概要
issue #75 対応。`@tanstack/react-query` を利用するための基盤を整備し、`ChatContainer` のAPI通信を `useMutation` に移行した。

- `lib/queryClient.ts` を新規作成し、QueryClient をデフォルト設定（queries: retry=2 / staleTime=5分、mutations: retry=1）で構成
- `app/providers.tsx` を新規作成し、`QueryClientProvider` を `"use client"` コンポーネントとして分離（Next.js App Router のサーバーコンポーネントと共存できる構造）
- `layout.tsx` で `<Providers>` によりアプリ全体をラップ
- `ChatContainer.tsx` の `useState(isLoading)` + `try/catch/finally` パターンを `useMutation` に置き換え

なお、バックエンドの `openapi.json` から `@hey-api/openapi-ts` でクライアントコードを生成する設定はすでに `@tanstack/react-query` プラグイン込みで構成済み。チャットエンドポイントが追加された際は `pnpm openapi:generate` を実行し、生成された SDK 関数に差し替えるだけで対応できる。

## 変更種別
- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] インフラ / CI

## 関連 Issue
closes #75

## テスト確認
- [x] ローカルで動作確認済み
    - チャット画面でメッセージ送信・ローディング表示・レスポンス表示が正常に動作することを確認
    - [x] Windows 11 / Chrome
- [x] 既存テストが通ることを確認（`pnpm lint` / `pnpm tsc --noEmit` / `pnpm build` がすべてパス）
- [ ] 新規テストを追加した（変更内容に応じて）

## スクリーンショット（UI変更がある場合）
なし（UI上の見た目に変更なし）

## レビュアーへのメモ
- `providers.tsx` を `layout.tsx` と別ファイルに分離しているのは、`QueryClientProvider` が `"use client"` を要求するため。`layout.tsx` をサーバーコンポーネントのまま保てる。
- `sendChatMessage` 関数を `ChatContainer` 外に切り出したのは、将来 Dify API 実装時に差し替えやすくするため。
- `@hey-api/openapi-ts` の設定（`openapi-ts.config.ts`）はすでに `@tanstack/react-query` プラグイン込みなので、チャットエンドポイントが OpenAPI に追加されれば hooks が自動生成される。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * チャット機能のメッセージ送信処理を最適化し、より堅牢な非同期処理を実装しました。
  * ローディング状態の管理を改善し、より正確なユーザーインターフェース反応を実現しました。

* **内部改善**
  * データ取得フレームワークを統合し、長期的な安定性と保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->