### PR TITLE
fix: worktree環境でのlefthook installエラーを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "prepare": "test -n \"$CI\" || lefthook install",
+    "prepare": "test -n \"$CI\" || lefthook install --reset-hooks-path",
     "dev": "turbo run dev",
     "build": "turbo run build",
     "lint": "turbo run lint",


### PR DESCRIPTION
## 概要
worktree環境で `pnpm install` を実行すると、`prepare` スクリプトの `lefthook install` が `core.hooksPath` の競合でエラーになる問題を修正。

`--reset-hooks-path` オプションを追加することで、lefthookが `core.hooksPath` を自動的にunsetして正常にインストールできるようになる。

## 変更種別
- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] インフラ / CI

## 関連 Issue
closes #111

## テスト確認
- [x] ローカルで動作確認済み
    - worktree環境で `pnpm install` を実行し、正常に完了することを確認
    - `core.hooksPath has been unset` のメッセージと共にhooksが正常にインストールされることを確認
    - [x] 動作環境: macOS
- [x] 既存テストが通ることを確認
- [ ] 新規テストを追加した（変更内容に応じて）

## スクリーンショット（UI変更がある場合）
なし

## レビュアーへのメモ
lefthookのヒントメッセージでも提示されている公式の対処法（`--reset-hooks-path`）を使用しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * npm スクリプト設定を更新しました。CI 環境外での開発環境セットアップに関する改善を実施しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->