### PR TITLE
feat(infra): Nixを用いた開発環境の宣言・共通化

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# Load Nix development environment
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ __pycache__/
 *.py[cod]
 .venv/
 
+# Nix / direnv
+.direnv/
+result
+result-*
+
 # Discord ingest (raw logs and processed output must not be committed)
 scripts/ingest/discord/raw/
 scripts/ingest/discord/out/

--- a/README.md
+++ b/README.md
@@ -138,7 +138,36 @@ root/
 
 ## セットアップ
 
-### 必要環境
+### Nix による自動セットアップ（推奨）
+
+Nix と direnv を使用すると、プロジェクトディレクトリに `cd` するだけで開発環境が自動的にセットアップされます。
+
+```bash
+# 1. Nix をインストール（未インストールの場合）
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+
+# 2. direnv をインストール（未インストールの場合）
+brew install direnv  # macOS
+# または: sudo apt install direnv  # Linux
+
+# 3. シェル設定に direnv フックを追加（~/.zshrc または ~/.bashrc）
+eval "$(direnv hook zsh)"  # zsh の場合
+# または: eval "$(direnv hook bash)"  # bash の場合
+
+# 4. プロジェクトディレクトリで direnv を許可
+cd /path/to/Jyogi_navi
+direnv allow
+```
+
+これで Node.js、pnpm、Python、uv などが自動的に利用可能になります。
+
+詳細なセットアップ手順は [docs/nix-setup.md](docs/nix-setup.md) を参照してください。
+
+### 手動セットアップ
+
+Nix を使用しない場合は、以下を手動でインストールしてください。
+
+#### 必要環境
 
 - Node.js 20+
 - Python 3.13+
@@ -256,6 +285,7 @@ TIDB_SSL_CA=/path/to/tidb-ca.pem
 | [docs/07_infrastructure.md](docs/07_infrastructure.md) | インフラ構成 |
 | [docs/08_logging.md](docs/08_logging.md) | ログ設計 |
 | [docs/09_schedule_and_issues.md](docs/09_schedule_and_issues.md) | スケジュールと課題 |
+| [docs/10_nix-setup.md](docs/10_nix-setup.md) | Nix 開発環境セットアップ |
 
 ---
 

--- a/docs/nix-setup.md
+++ b/docs/nix-setup.md
@@ -1,0 +1,228 @@
+# 10_nix-setup
+
+作成日時: 2026年3月25日
+最終更新者: KOU050223
+
+# Nix 開発環境セットアップガイド
+
+このプロジェクトでは Nix Flakes と direnv を使用して、統一された開発環境を提供しています。
+
+---
+
+## 0️⃣ 前提条件
+
+| 項目 | 内容 |
+| --- | --- |
+| 対応OS | macOS, Linux |
+| 所要時間 | 初回セットアップ: 約10-15分 |
+| ディスク容量 | 約2-3GB（Nix store） |
+
+---
+
+## 1️⃣ Nix のインストール
+
+### macOS / Linux 共通
+
+```bash
+# Determinate Systems インストーラー（推奨）
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+```
+
+または公式インストーラー:
+
+```bash
+sh <(curl -L https://nixos.org/nix/install) --daemon
+```
+
+インストール後、新しいターミナルを開くか、以下を実行:
+
+```bash
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+```
+
+### 確認
+
+```bash
+nix --version
+# nix (Nix) 2.x.x
+```
+
+---
+
+## 2️⃣ Flakes の有効化
+
+Determinate Systems インストーラーを使用した場合、Flakes は自動的に有効化されています。
+
+公式インストーラーを使用した場合は、以下を設定:
+
+```bash
+mkdir -p ~/.config/nix
+echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+```
+
+---
+
+## 3️⃣ direnv のインストール
+
+### macOS (Homebrew)
+
+```bash
+brew install direnv
+```
+
+### Linux (apt)
+
+```bash
+sudo apt install direnv
+```
+
+### シェル設定
+
+使用しているシェルに応じて設定を追加:
+
+**Bash** (`~/.bashrc`):
+```bash
+eval "$(direnv hook bash)"
+```
+
+**Zsh** (`~/.zshrc`):
+```zsh
+eval "$(direnv hook zsh)"
+```
+
+**Fish** (`~/.config/fish/config.fish`):
+```fish
+direnv hook fish | source
+```
+
+設定後、シェルを再起動:
+
+```bash
+exec $SHELL
+```
+
+---
+
+## 4️⃣ nix-direnv のインストール（推奨）
+
+nix-direnv を使用すると、環境のキャッシュが効いて切り替えが高速になります。
+
+```bash
+# Homebrewの場合
+brew install nix-direnv
+
+# または Nix 経由
+nix profile install nixpkgs#nix-direnv
+```
+
+direnv の設定に追加 (`~/.config/direnv/direnvrc`):
+
+```bash
+source $HOME/.nix-profile/share/nix-direnv/direnvrc
+# または Homebrew の場合
+source $(brew --prefix nix-direnv)/share/nix-direnv/direnvrc
+```
+
+---
+
+## 5️⃣ プロジェクトでの使用
+
+### 初回セットアップ
+
+```bash
+cd /path/to/Jyogi_navi
+
+# direnv を許可
+direnv allow
+```
+
+初回は依存パッケージのダウンロードに数分かかります。
+
+### 動作確認
+
+```bash
+# 自動的に開発環境がロードされる
+cd /path/to/Jyogi_navi
+
+# ツールのバージョン確認
+node --version    # v20.x.x
+pnpm --version    # 9.x.x
+python --version  # Python 3.13.x
+uv --version
+gh --version
+```
+
+### 手動でシェルに入る場合
+
+```bash
+nix develop
+```
+
+---
+
+## 6️⃣ トラブルシューティング
+
+### direnv: error .envrc is blocked
+
+```bash
+direnv allow
+```
+
+### Flakes が有効になっていない
+
+```bash
+# nix.conf を確認
+cat ~/.config/nix/nix.conf
+
+# experimental-features = nix-command flakes が含まれていることを確認
+```
+
+### 環境が古い場合
+
+```bash
+# flake.lock を更新
+nix flake update
+
+# 環境を再読み込み
+direnv reload
+```
+
+### キャッシュをクリア
+
+```bash
+# direnv キャッシュを削除
+rm -rf .direnv/
+
+# 再読み込み
+direnv allow
+```
+
+---
+
+## 7️⃣ よくある質問
+
+### Q: Nix を使わずに開発できますか？
+
+A: はい。従来通り手動で Node.js、Python、pnpm、uv などをインストールしても開発できます。ただし、バージョンの一致は各自で管理する必要があります。
+
+### Q: CI/CD でも Nix を使いますか？
+
+A: 現時点では GitHub Actions で直接ツールをインストールしています。将来的に Nix に統一する可能性があります。
+
+### Q: ディスク容量が心配です
+
+A: Nix store は `~/.nix` または `/nix/store` に保存されます。不要なパッケージは以下で削除できます:
+
+```bash
+nix-collect-garbage -d
+```
+
+---
+
+## 8️⃣ 参考リンク
+
+- [Nix 公式ドキュメント](https://nixos.org/manual/nix/stable/)
+- [Nix Flakes](https://nixos.wiki/wiki/Flakes)
+- [direnv](https://direnv.net/)
+- [nix-direnv](https://github.com/nix-community/nix-direnv)
+- [Determinate Systems Nix Installer](https://github.com/DeterminateSystems/nix-installer)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774106199,
+        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "Jyogi Navi development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Node.js
+            nodejs_20
+            pnpm
+
+            # Python
+            python313
+            uv
+
+            # Development tools
+            lefthook
+            gh
+          ];
+
+          shellHook = ''
+            echo "🚀 Jyogi Navi development environment loaded!"
+            echo ""
+            echo "Available tools:"
+            echo "  - Node.js $(node --version)"
+            echo "  - pnpm $(pnpm --version)"
+            echo "  - Python $(python --version | cut -d' ' -f2)"
+            echo "  - uv $(uv --version | cut -d' ' -f2)"
+            echo "  - lefthook $(lefthook version)"
+            echo "  - gh $(gh --version | head -n1 | cut -d' ' -f3)"
+            echo ""
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## 概要

Nix Flakes + direnv を使用して、プロジェクトディレクトリに `cd` するだけで開発環境が自動的に切り替わる仕組みを導入します。

## 変更内容

### 新規ファイル
- **`flake.nix`** - Nix Flakes で開発環境を宣言的に定義
- **`.envrc`** - direnv 連携設定（`use flake`）
- **`flake.lock`** - 依存バージョンをロック
- **`docs/nix-setup.md`** - セットアップガイド

### 更新ファイル
- **`.gitignore`** - `.direnv/`, `result`, `result-*` を除外
- **`README.md`** - Nix によるセットアップ手順を追加

## 含まれるツール

| ツール | バージョン |
|--------|----------|
| Node.js | v20.20.1 |
| pnpm | 9.15.0 |
| Python | 3.13.12 |
| uv | 0.10.12 |
| lefthook | 2.1.1 |
| gh | 2.88.1 |

## 使い方

```bash
# 初回のみ direnv を許可
direnv allow

# 以降は cd するだけで自動切り替え
cd /path/to/Jyogi_navi
```

## 関連 Issue

closes #126

## チェックリスト

- [x] `flake.nix` が作成され、`nix develop` で開発環境に入れる
- [x] `.envrc` が作成され、`cd` で自動的に環境がロードされる
- [x] `.gitignore` にNix関連パターンが追加されている
- [x] `docs/nix-setup.md` にセットアップ手順が記載されている
- [x] `README.md` にNix環境での開発手順が追記されている
- [x] ローカル環境で動作確認完了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * Nix と direnv を用いた開発環境セットアップの詳細ガイドを追加しました（手順、トラブルシューティング、FAQ、参考リンク含む）。README に自動セットアップ（Nix）セクションを追加し、手動セットアップはその後に移動しました。

* **Chores**
  * 開発環境セットアップ構成を追加・更新しました。プロジェクトで Nix ベースの開発シェルを利用できるようになり、Node.js・pnpm・Python・uv 等が自動で利用可能になります。
  * 一時生成物や環境ファイルを無視するための .gitignore を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->